### PR TITLE
Correct documentation to have the correct future/past times

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ From [Oauth JSON Web Token 4.1.4. "exp" (Expiration Time) Claim](https://tools.i
 **Handle Expiration Claim**
 
 ```ruby
-exp = Time.now.to_i + 4 * 3600
+exp = Time.now.to_i - 4 * 3600
 exp_payload = { :data => 'data', :exp => exp }
 
 token = JWT.encode exp_payload, hmac_secret, 'HS256'
@@ -262,7 +262,7 @@ From [Oauth JSON Web Token 4.1.5. "nbf" (Not Before) Claim](https://tools.ietf.o
 **Handle Not Before Claim**
 
 ```ruby
-nbf = Time.now.to_i - 3600
+nbf = Time.now.to_i + 3600
 nbf_payload = { :data => 'data', :nbf => nbf }
 
 token = JWT.encode nbf_payload, hmac_secret, 'HS256'


### PR DESCRIPTION
I noticed that the code in the documentation was wrong.

the nbf time used a "time in the past" instead of a "time in the future" the code as written would not have raised the error being demonstrated. Same was true for the token exp demo. The exp was being set to time in the future and so the token would not yet be expired. To get the demoed error to raise, you would have to set the exp to time in the past.